### PR TITLE
chore: add dependabot config and npm supply-chain hardening

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily
+      time: '00:30'
+      timezone: Europe/Berlin
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      include:
+        - '*'
+
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: daily
+      time: '01:30'
+      timezone: Europe/Berlin
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      include:
+        - '*'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major
+
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+      time: '02:00'
+      timezone: Europe/Berlin
+    versioning-strategy: increase-if-necessary
+    cooldown:
+      default-days: 7
+      semver-patch-days: 3
+      include:
+        - '*'
+    ignore:
+      - dependency-name: '*'
+        update-types:
+          - version-update:semver-major

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+ignore-scripts=true
+min-release-age=7


### PR DESCRIPTION
Activates dependabot (the auto-merge workflow existed but no config was present, so no PRs were being created) and adds npm supply-chain hardening.

**`.github/dependabot.yml`**
- Covers github-actions, composer, npm
- Daily schedule, staggered times (Europe/Berlin)
- 7-day cooldown on new versions (3 days for patches) — lets the ecosystem shake out malicious or broken releases before they land here
- Ignores semver-major for composer/npm (too risky to auto-merge; bump manually)

**`.npmrc`**
- `ignore-scripts=true` — blocks arbitrary postinstall scripts (the main vector used by compromised npm packages)
- `min-release-age=7` — refuses to install any package version released less than 7 days ago; mirrors the dependabot cooldown

Pairs with the existing `dependabot-auto-merge.yml` workflow, which will now start receiving PRs to auto-merge (semver-minor + semver-patch only).