### PR TITLE
Update prism-php/prism version to ^0.100

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require": {
         "statamic/cms": "^6.0",
-        "prism-php/prism": "^0.99"
+        "prism-php/prism": "^0.100"
     },
     "require-dev": {
         "orchestra/testbench": "^9.0 || ^10.0",


### PR DESCRIPTION
We can't update this add-on, since the add-on "Magic Translator" uses prism ^0.100 which does not get resolved.