### PR TITLE
fix: allow prism 0.100 alongside 0.99

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,13 +8,14 @@ on:
 
 jobs:
   test:
-    name: CI – PHP ${{ matrix.php }}
+    name: CI – PHP ${{ matrix.php }} / Prism ${{ matrix.prism }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: true
       matrix:
         php: ['8.3', '8.4']
+        prism: ['^0.99', '^0.100']
 
     steps:
       - uses: actions/checkout@v4
@@ -36,9 +37,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            composer-${{ matrix.php }}-
+          key: composer-${{ matrix.php }}-prism${{ matrix.prism }}
+
+      # Pin the Prism minor under test so the declared range is proven at both ends.
+      - name: Select Prism version
+        run: composer require "prism-php/prism:${{ matrix.prism }}" --no-update --no-interaction
 
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require": {
         "statamic/cms": "^6.0",
-        "prism-php/prism": "^0.99"
+        "prism-php/prism": "^0.99 || ^0.100"
     },
     "require-dev": {
         "orchestra/testbench": "^9.0 || ^10.0",

--- a/tests/Feature/PrismCaptionServiceTest.php
+++ b/tests/Feature/PrismCaptionServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use ElSchneider\StatamicAutoAltText\Contracts\CaptionService;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Testing\TextResponseFake;
+use Prism\Prism\ValueObjects\Media\Image;
+
+// Pins the Prism request chain used by PrismCaptionService. Prism ships breaking
+// changes in 0.x minors, so the supported range in composer.json is only credible
+// if this runs against every minor in it.
+it('sends the image through Prism and returns the caption', function () {
+    $fake = Prism::fake([
+        TextResponseFake::make()->withText('A white square.'),
+    ]);
+
+    $asset = $this->createTestAsset();
+
+    $caption = app(CaptionService::class)->generateCaption($asset);
+
+    expect($caption)->toBe('A white square.');
+
+    $fake->assertRequest(function (array $requests) {
+        $request = collect($requests)->flatten()->sole();
+
+        expect($request->provider())->toBe('openai')
+            ->and($request->model())->toBe('gpt-4.1')
+            ->and($request->maxTokens())->toBe(config('statamic.auto-alt-text.max_tokens'));
+
+        $images = collect($request->messages())
+            ->flatMap(fn ($message) => $message->images())
+            ->filter(fn ($part) => $part instanceof Image);
+
+        expect($images)->toHaveCount(1);
+    });
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use ElSchneider\StatamicAutoAltText\ServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Prism\Prism\PrismServiceProvider;
 // use RuntimeException;
 use RuntimeException;
 use Statamic\Testing\AddonTestCase;
@@ -30,6 +31,11 @@ abstract class TestCase extends AddonTestCase
         }
 
         parent::tearDown();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [...parent::getPackageProviders($app), PrismServiceProvider::class];
     }
 
     protected function resolveApplicationConfiguration($app)


### PR DESCRIPTION
`^0.99` resolves to `>=0.99.0 <0.100.0` — Composer's caret pins the minor on 0.x releases. Prism 0.100 is an ordinary next minor, so the addon could not be installed next to anything already requiring it.

Widening to `^0.99 || ^0.100` instead of moving to `^0.100` exclusively: an exclusive bump would block the opposite group of users, who hold 0.99, for no technical gain.

The 0.100 breaking changes are limited to structured output and citations. This addon only calls `Prism::text()` with an image attachment, so it is unaffected.

Verified locally on both ends of the range (`0.99.22` and `0.100.1`): 8 passed, 14 assertions.

Also here:

- CI now runs the suite once per supported Prism minor, so the declared range is proven rather than assumed.
- A new feature test pins the request chain (provider, model, max tokens, image attachment) via `Prism::fake()`. Prism ships breaking changes in 0.x minors, and nothing covered that call path before.
- `TestCase` registers `PrismServiceProvider`, which Testbench does not load automatically.
