### PR TITLE
chore: repair dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,9 +6,10 @@ updates:
       interval: daily
       time: '00:30'
       timezone: Europe/Berlin
+    # The GitHub Actions ecosystem supports only default-days; a SemVer-bump
+    # cooldown key here invalidates the whole file and stops all version updates.
     cooldown:
       default-days: 7
-      semver-patch-days: 3
       include:
         - '*'
 
@@ -18,6 +19,9 @@ updates:
       interval: daily
       time: '01:30'
       timezone: Europe/Berlin
+    # This addon is a library: widen constraints to keep both the old and new
+    # release installable rather than replacing the supported range.
+    versioning-strategy: widen
     cooldown:
       default-days: 7
       semver-patch-days: 3


### PR DESCRIPTION
The GitHub Actions ecosystem supports only `default-days` for cooldown. The `semver-patch-days` key in that block invalidated the config, so no version updates ran for any ecosystem.

Composer also gets `versioning-strategy: widen`, so a new dependency minor arrives as a range-widening pull request rather than silently blocking installs, which is the failure that prompted this.

Dependabot reads its config from the default branch, so recovery can only be confirmed after merge.
