### PR TITLE
fix: allow prism 0.100 alongside 0.99

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,19 +2,20 @@ name: Tests
 
 on:
   push:
-    branches: [main]
+    branches: [main, v1.x]
   pull_request:
-    branches: [main]
+    branches: [main, v1.x]
 
 jobs:
   test:
-    name: CI – PHP ${{ matrix.php }}
+    name: CI – PHP ${{ matrix.php }} / Prism ${{ matrix.prism }}
     runs-on: ubuntu-latest
 
     strategy:
       fail-fast: true
       matrix:
         php: ['8.3', '8.4']
+        prism: ['^0.99', '^0.100']
 
     steps:
       - uses: actions/checkout@v4
@@ -36,9 +37,11 @@ jobs:
         uses: actions/cache@v4
         with:
           path: vendor
-          key: composer-${{ matrix.php }}-${{ hashFiles('composer.lock') }}
-          restore-keys: |
-            composer-${{ matrix.php }}-
+          key: composer-${{ matrix.php }}-prism${{ matrix.prism }}
+
+      # Pin the Prism minor under test so the declared range is proven at both ends.
+      - name: Select Prism version
+        run: composer require "prism-php/prism:${{ matrix.prism }}" --no-update --no-interaction
 
       - name: Install Composer dependencies
         run: composer install --no-interaction --prefer-dist --optimize-autoloader

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require": {
         "statamic/cms": "^5.0",
-        "prism-php/prism": "^0.99"
+        "prism-php/prism": "^0.99 || ^0.100"
     },
     "require-dev": {
         "orchestra/testbench": "^9.0 || ^10.0",

--- a/tests/Browser/UiActionTest.php
+++ b/tests/Browser/UiActionTest.php
@@ -12,8 +12,10 @@ beforeEach(function () {
 it('display field action on edit page', function () {
     $url = "/cp/assets/browse/{$this->asset->containerHandle()}/{$this->asset->basename()}/edit";
 
+    // Statamic 5 renders field actions in a quick-list dropdown; the
+    // data-ui-dropdown-trigger primitive only exists from Statamic 6 on.
     visit($url)
         ->waitForText('Alt Text')
-        ->click('.text-fieldtype [data-ui-dropdown-trigger]')
+        ->click('.text-fieldtype .quick-list button')
         ->assertSee('Generate Alt Text');
 });

--- a/tests/Feature/PrismCaptionServiceTest.php
+++ b/tests/Feature/PrismCaptionServiceTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+use ElSchneider\StatamicAutoAltText\Contracts\CaptionService;
+use Prism\Prism\Facades\Prism;
+use Prism\Prism\Testing\TextResponseFake;
+use Prism\Prism\ValueObjects\Media\Image;
+
+// Pins the Prism request chain used by PrismCaptionService. Prism ships breaking
+// changes in 0.x minors, so the supported range in composer.json is only credible
+// if this runs against every minor in it.
+it('sends the image through Prism and returns the caption', function () {
+    $fake = Prism::fake([
+        TextResponseFake::make()->withText('A white square.'),
+    ]);
+
+    $asset = $this->createTestAsset();
+
+    $caption = app(CaptionService::class)->generateCaption($asset);
+
+    expect($caption)->toBe('A white square.');
+
+    $fake->assertRequest(function (array $requests) {
+        $request = collect($requests)->flatten()->sole();
+
+        expect($request->provider())->toBe('openai')
+            ->and($request->model())->toBe('gpt-4.1')
+            ->and($request->maxTokens())->toBe(config('statamic.auto-alt-text.max_tokens'));
+
+        $images = collect($request->messages())
+            ->flatMap(fn ($message) => $message->images())
+            ->filter(fn ($part) => $part instanceof Image);
+
+        expect($images)->toHaveCount(1);
+    });
+});

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@ namespace Tests;
 
 use ElSchneider\StatamicAutoAltText\ServiceProvider;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Prism\Prism\PrismServiceProvider;
 // use RuntimeException;
 use RuntimeException;
 use Statamic\Testing\AddonTestCase;
@@ -30,6 +31,11 @@ abstract class TestCase extends AddonTestCase
         }
 
         parent::tearDown();
+    }
+
+    protected function getPackageProviders($app)
+    {
+        return [...parent::getPackageProviders($app), PrismServiceProvider::class];
     }
 
     protected function resolveApplicationConfiguration($app)


### PR DESCRIPTION
Backports the Prism 0.100 constraint fix to the Statamic 5 line.

Composer's caret pins the minor on 0.x, so `^0.99` excluded 0.100 and blocked installs alongside packages already requiring it. This addon only uses text generation with an image attachment, which 0.100 leaves unchanged. A CI matrix and a test covering the request chain check both ends of the range.

The tests workflow only triggered on `main`, so this branch ran no checks at all; it now also triggers on `v1.x`. That exposed a browser test selecting the field action through a dropdown attribute that only exists from Statamic 6 on, fixed here in a separate commit against the Statamic 5 control panel markup.
